### PR TITLE
@types/quill support and fix angular2 AOT compile error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,15 @@ Quill editor for Angular2，基于Quill、适用于Angular2的富文本编辑器
 npm install ng2-quill-editor --save
 ```
 
+``` bash
+npm install --save-dev @types/quill
+```
+
 
 ### Sample
-Include QuillEditorModule in your main module :
+First of all, include script `node_modules/quill/dist/quill.js` that ng2-quill-editor dependented in proper way;
+
+Next Include QuillEditorModule in your main module :
 ``` javascript
 import { QuillEditorModule } from 'ng2-quill-editor';
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install --save-dev @types/quill
 
 
 ### Sample
-First of all, include script `node_modules/quill/dist/quill.js` that ng2-quill-editor dependented in proper way;
+First of all, include script `node_modules/quill/dist/quill.js` that `ng2-quill-editor` dependented in proper way;
 
 Next Include QuillEditorModule in your main module :
 ``` javascript

--- a/quillEditor.component.ts
+++ b/quillEditor.component.ts
@@ -12,16 +12,14 @@ import {
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 
-const Quill = require('quill/dist/quill.js');
-
 @Component({
   selector: 'quill-editor',
   template: `<div></div>`,
   styles: [
-    require('./quillEditor.component.css'),
-    require('quill/dist/quill.snow.css'),
-    require('quill/dist/quill.bubble.css'),
-    require('quill/dist/quill.core.css')
+    './quillEditor.component.css',
+    '../quill/dist/quill.snow.css',
+    '../quill/dist/quill.bubble.css',
+    '../quill/dist/quill.core.css'
   ],
   providers: [{
     provide: NG_VALUE_ACCESSOR,

--- a/quillEditor.component.ts
+++ b/quillEditor.component.ts
@@ -15,7 +15,7 @@ import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 @Component({
   selector: 'quill-editor',
   template: `<div></div>`,
-  styles: [
+  styleUrls: [
     './quillEditor.component.css',
     '../quill/dist/quill.snow.css',
     '../quill/dist/quill.bubble.css',


### PR DESCRIPTION
1.新增typescript quill 类型定义支持
2.修复angular2 AOT 编译过程中，由webpack `require` 引起的错误